### PR TITLE
Add wheel build configuration to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,12 @@ dev = [
 
 [tool.hatch.build.targets.sdist]
 only-include = ["my_pkg",]
+source = "."
+
+[tool.hatch.build.targets.wheel]
+only-include = ["my_pkg",]
+source = "."
+
 
 
 [build-system]

--- a/uv.lock
+++ b/uv.lock
@@ -169,7 +169,7 @@ wheels = [
 
 [[package]]
 name = "my-pkg"
-version = "0.0.0.post14.dev0+e36b857"
+version = "0.0.0.post16.dev0+19e05be"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Added a wheel build target in the Hatch configuration alongside the sdist target. Both now specify "my_pkg" as the only included package and use the current directory as the source. This ensures consistent build behavior for both distribution formats.