### PR TITLE
Update dependabot config, Python version, and README badge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
+enable-beta-ecosystems: true
+
 updates:
   - package-ecosystem: "pip" # See documentation for possible values
     directory: "/" # Location of package manifests

--- a/README.md
+++ b/README.md
@@ -12,3 +12,4 @@
 [![Code Checks](https://github.com/DanielAvdar/python-template/actions/workflows/code-checks.yml/badge.svg)](https://github.com/DanielAvdar/python-template/actions/workflows/code-checks.yml)
 [![codecov](https://codecov.io/gh/DanielAvdar/python-template/graph/badge.svg?token=N0V9KANTG2)](https://codecov.io/gh/DanielAvdar/python-template)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
+![Last Commit](https://img.shields.io/github/last-commit/DanielAvdar/python-template/main)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
-requires-python = ">=3.9,<4"
+requires-python = ">=3.9"
 
 keywords = [
     "python"


### PR DESCRIPTION
Enabled beta ecosystems in dependabot.yml for enhanced dependency updates. Relaxed the Python version constraint in pyproject.toml to support 4.x releases. Added a "Last Commit" badge to the README for better project tracking.