### PR TITLE
Add Renovate config and update package version placeholder

### DIFF
--- a/my_pkg/__init__.py
+++ b/my_pkg/__init__.py
@@ -1,3 +1,3 @@
 from importlib.metadata import version
 
-__version__ = version("my-pkg")
+__version__ = version("my-pkg")  # todo: replace with your package name

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "python": {
+    "lockFileMaintenance": {
+      "enabled": true
+    }
+  },
+  "schedule": [
+    "every day"
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["uv"],
+      "groupName": false
+
+    }
+  ]
+}


### PR DESCRIPTION
Introduce a `renovate.json` file with a recommended configuration to manage dependencies. Updated `__init__.py` to include a placeholder comment for replacing the package name in the version call.