### PR TITLE
Update Renovate schedule to run before 2am daily

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,7 @@
     }
   },
   "schedule": [
-    "every day"
+    "before 2am every day"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
The schedule for Renovate has been adjusted from "every day" to "before 2am every day." This ensures updates are processed earlier in the day, allowing for smoother workflows.