### PR TITLE
Update Renovate schedule to allow updates at any time

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,7 @@
     }
   },
   "schedule": [
-    "before 2am every day"
+    "at any time"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
Changed the schedule from "before 2am every day" to "at any time" to allow greater flexibility for dependency updates. This ensures updates can run whenever needed without time restrictions.