### PR TITLE
Add label configuration to Renovate package rules

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,10 +11,32 @@
   "schedule": [
     "at any time"
   ],
+  "labels": [
+    "renovate"
+  ],
   "packageRules": [
     {
       "matchManagers": [
         "uv"
+      ]
+    },
+    {
+      "matchManagers": [
+        "github-actions"
+      ],
+      "labels": [
+        "github-actions"
+      ]
+    },
+    {
+      "matchManagers": [
+        "uv",
+        "pip",
+        "poetry",
+        "pipenv"
+      ],
+      "labels": [
+        "python"
       ]
     }
   ]


### PR DESCRIPTION
Labels were added to categorize dependencies managed by Renovate. This includes labels for GitHub Actions, Python-related managers, and a general Renovate label. These changes improve organization and clarity in dependency management.