### PR TITLE
Update pre-commit and Renovate config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
       - id: trailing-whitespace
       - id: no-commit-to-branch
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.6
+    rev: v0.11.5
     hooks:
       - id: ruff-format
         args: [ --preview, --config=pyproject.toml ]

--- a/renovate.json
+++ b/renovate.json
@@ -18,11 +18,6 @@
   "packageRules": [
     {
       "matchManagers": [
-        "uv"
-      ]
-    },
-    {
-      "matchManagers": [
         "github-actions"
       ],
       "labels": [
@@ -31,9 +26,19 @@
     },
     {
       "matchManagers": [
-        "uv",
-        "pip"
-
+        "pre-commit"
+      ],
+      "labels": [
+        "pre-commit"
+      ]
+    },
+    {
+      "matchManagers": [
+        "pip-compile",
+        "pip_requirements",
+        "pip_setup",
+        "pipenv",
+        "poetry"
       ],
       "labels": [
         "python"


### PR DESCRIPTION
Downgraded ruff-pre-commit hook to v0.11.5 in .pre-commit-config.yaml. Adjusted Renovate rules by reorganizing matchManagers and adding labels to enhance clarity and alignment with current package management needs.