### PR TITLE
Update Renovate config by removing `prTitle` field

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,7 +14,6 @@
   "labels": [
     "renovate"
   ],
-  "prTitle": "renovate: {{description}}",
   "packageRules": [
     {
       "matchManagers": [

--- a/renovate.json
+++ b/renovate.json
@@ -20,7 +20,8 @@
         "github-actions"
       ],
       "labels": [
-        "github-actions"
+        "github-actions",
+        "renovate"
       ]
     },
     {
@@ -28,7 +29,8 @@
         "pre-commit"
       ],
       "labels": [
-        "pre-commit"
+        "pre-commit",
+        "renovate"
       ]
     },
     {
@@ -40,7 +42,8 @@
         "poetry"
       ],
       "labels": [
-        "python"
+        "python",
+        "renovate"
       ]
     }
   ]


### PR DESCRIPTION
The `prTitle` field was removed from the configuration as it is no longer needed. This simplifies the file and ensures Renovate uses its default PR title formatting.