### PR TITLE
Enable Renovate updates for pre-commit configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,9 @@
       "enabled": true
     }
   },
+  "pre-commit": {
+    "enabled": true
+  },
   "schedule": [
     "at any time"
   ],


### PR DESCRIPTION
This change ensures that Renovate can manage updates for pre-commit hooks. It improves automation and keeps dependencies up to date more efficiently.