### PR TITLE
Enable automerge for Python lock file maintenance

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,9 @@
   ],
   "python": {
     "lockFileMaintenance": {
-      "enabled": true
+      "enabled": true,
+      "automerge": true
+
     }
   },
   "automerge": true,


### PR DESCRIPTION
This update adds the `automerge` option to the Python lock file maintenance configuration. It ensures that dependency updates are automatically merged once passing all required checks, streamlining the update process.