### PR TITLE
Enhance docstrings checks & Fix pre-commit execution on commit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ default: install
 install:
 	uv sync --all-extras --all-groups --frozen
 	uv tool install pre-commit --with pre-commit-uv --force-reinstall
+	uv run pre-commit install
 
 install-docs:
 	uv sync --group docs --frozen --no-group dev

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,12 +64,12 @@ line-length = 120
 include = ["pyproject.toml", "tests/**", ]
 
 [tool.ruff.lint]
-select = ["F", "B", "I", "F", "W", "E", "A", "N", "D"]
+select = ["F", "B", "I", "F", "W", "E", "A", "N", "D","DOC"]
 
 fixable = ["ALL"]
 [tool.ruff.lint.per-file-ignores]
-"tests/*" = ["D"]
-"docs/*" = ["D"]
+"tests/*" = ["D", "DOC"]
+"docs/*" = ["D", "DOC"]
 [tool.ruff.lint.isort]
 combine-as-imports = true
 [tool.mypy]


### PR DESCRIPTION
Ensure `uv run pre-commit install` is executed during installation across multiple projects. This change guarantees pre-commit hooks are properly installed, improving development workflows and code quality consistency.