### PR TITLE
Update Renovate config to refine lock file management

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,12 +3,13 @@
   "extends": [
     "config:recommended"
   ],
-  "python": {
-    "lockFileMaintenance": {
-      "enabled": true,
-      "automerge": true
-
-    }
+  "lockFileMaintenance": {
+    "enabled": true,
+    "automerge": true,
+    "schedule": [
+      "at any time"
+    ],
+    "groupName": "uv-lock"
   },
   "automerge": true,
   "pre-commit": {
@@ -41,14 +42,10 @@
     },
     {
       "matchManagers": [
-        "pip-compile",
-        "pip_requirements",
-        "pip_setup",
-        "pipenv",
-        "poetry"
+        "uv-lock"
       ],
       "labels": [
-        "python",
+        "uv-lock",
         "renovate"
       ]
     }


### PR DESCRIPTION
Refactored the Renovate configuration to group and schedule lock file maintenance under "uv-lock." Adjusted match managers and labels to align with the new grouping, improving clarity and automation control.